### PR TITLE
Delete original source when copying executables and extra dirs

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -76,13 +76,23 @@ for BUILDPACK in $(cat $1/.buildpacks); do
         # check if the buildpack left any executables behind
         if [ -d $1/$subdir/.heroku ]; then
           mkdir -p $1/.heroku
-          cp -R $1/$subdir/.heroku/* $1/.heroku
+          cp -R $1/$subdir/.heroku/* $1/.heroku && rm -rf $1/$subdir/.heroku
+        fi
+
+        if [ -d $1/$subdir/bin ]; then
+          mkdir -p $1/bin
+          cp -R $1/$subdir/bin/* $1/bin && rm -rf $1/$subdir/bin
+        fi
+
+        if [ -d $1/$subdir/vendor ]; then
+          mkdir -p $1/vendor
+          cp -R $1/$subdir/vendor/* $1/vendor && rm -rf $1/$subdir/vendor
         fi
 
         # check if the buildpack left any .profile.d scripts behind
         if [ -d $1/$subdir/.profile.d ]; then
           mkdir -p $1/.profile.d
-          cp -R $1/$subdir/.profile.d/* $1/.profile.d
+          cp -R $1/$subdir/.profile.d/* $1/.profile.d && rm -rf $1/$subdir/.profile.d
         fi
       fi
 


### PR DESCRIPTION
Sorry bothering again :)

I noticed that by not removing the directory in my last change, the slug size increased significantly. Without removing them, you basically end up with two copies of all executables. So two Python executables and two Node executables. Depending on the buildpacks you use of course.

On top of that, it seems that the pgbouncer buildpack also uses the `bin` and `vendor` directories.