### PR TITLE
Add license file and badge, more complicated examples for README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/bin/compile
+++ b/bin/compile
@@ -51,7 +51,7 @@ for BUILDPACK in $(cat $1/.buildpacks); do
     # Ensure that these files exist.
     chmod -f +x $dir/bin/{detect,compile,release} || true
 
-    framework=$($dir/bin/detect $1/$subdir)
+    framework=$(bash $dir/bin/detect $1/$subdir)
 
     if [ $? == 0 ]; then
       echo "=====> Detected Framework: $framework"
@@ -61,7 +61,7 @@ for BUILDPACK in $(cat $1/.buildpacks); do
       # echo "-----> Ls \$2: $(ls -la $2)"
       # echo "-----> Ls SUB_DIR(\$1/\$subdir): $(ls -la $1/$subdir)"
       # bin/compile BUILD_DIR CACHE_DIR ENV_DIR
-      $dir/bin/compile $1/$subdir $2 $3
+      bash $dir/bin/compile $1/$subdir $2 $3
 
       if [ $? != 0 ]; then
         exit 1

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,8 @@
 # Heroku Buildpack Subdir
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+
 Allows you to compose multiple buildpacks with apps in multiple directories. For information regarding adding multiple buildpacks, check out the official docs [here](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app#adding-a-buildpack).
 
 This buildpack must be at index 1 and all buildpacks following should be at index 2 through N.
@@ -11,16 +14,18 @@ This buildpack must be at index 1 and all buildpacks following should be at inde
 Example `.buildpacks` file:
 
     $ cat .buildpacks
-    api=https://github.com/heroku/heroku-buildpack-ruby.git
-    web=https://github.com/heroku/heroku-buildpack-nodejs.git
+    https://github.com/heroku/heroku-buildpack-nginx
+    api=https://github.com/heroku/heroku-buildpack-ruby
+    web=https://github.com/heroku/heroku-buildpack-nodejs
+    web=https://github.com/heroku/heroku-buildpack-pgbouncer
     https://github.com/heroku/heroku-buildpack-go
 
 This would run:
 
-* The first buildpack would `cd` into an `api` directory and use a `ruby` buildpack.
-* The second would `cd` into a `web` directory and use a `node.js` buildpack.
-* The third would be in the root directory and use a `go` buildpack.
+* The first buildpack would be in the root directory use use the `ngin` buildpack.
+* The second buildpack would `cd` into an `api` directory and use a `ruby` buildpack.
+* The third would `cd` into a `web` directory and use a `nodejs` buildpack.
+* The fourth would `cd` into a `web` directory and use a `pgbouncer` buildpack.
+* The firth would be in the root directory and use a `go` buildpack.
 
-## License
-
-MIT
+Buildpacks are executed in the order they are declared.


### PR DESCRIPTION
It wasn't entirely obvious at first to me that you could declare the same directory multiple times or that global buildpacks could also be run before subdirectory ones. I've updated the example in README to make this more clear.

Adding the `LICENSE` file allows Github to classify it properly. This helps users filter it when searching for repositories with a specific license.