### PR TITLE
Source .profile.d scripts from buildpacks in subdirs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/bin/compile
+++ b/bin/compile
@@ -62,7 +62,7 @@ for BUILDPACK in $(cat $1/.buildpacks); do
       # echo "-----> Ls \$2: $(ls -la $2)"
       # echo "-----> Ls SUB_DIR(\$1/\$subdir): $(ls -la $1/$subdir)"
       # bin/compile BUILD_DIR CACHE_DIR ENV_DIR
-      export ROOT_BUILD_DIR="$1"
+      export SUBDIR_ROOT_BUILD_DIR="$1"
       $dir/bin/compile $1/$subdir $2 $3
 
       if [ $? != 0 ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -62,6 +62,7 @@ for BUILDPACK in $(cat $1/.buildpacks); do
       # echo "-----> Ls \$2: $(ls -la $2)"
       # echo "-----> Ls SUB_DIR(\$1/\$subdir): $(ls -la $1/$subdir)"
       # bin/compile BUILD_DIR CACHE_DIR ENV_DIR
+      export ROOT_BUILD_DIR="$1"
       $dir/bin/compile $1/$subdir $2 $3
 
       if [ $? != 0 ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -12,6 +12,7 @@ function indent() {
 
 unset GIT_DIR
 
+subdirs=()
 for BUILDPACK in $(cat $1/.buildpacks); do
   dir=$(mktemp -t buildpackXXXXX)
   rm -rf $dir
@@ -73,17 +74,7 @@ for BUILDPACK in $(cat $1/.buildpacks); do
       fi
 
       if [ ! -z $subdir ]; then
-        # check if the buildpack left any executables behind
-        if [ -d $1/$subdir/.heroku ]; then
-          mkdir -p $1/.heroku
-          cp -R $1/$subdir/.heroku/* $1/.heroku
-        fi
-
-        # check if the buildpack left any .profile.d scripts behind
-        if [ -d $1/$subdir/.profile.d ]; then
-          mkdir -p $1/.profile.d
-          cp -R $1/$subdir/.profile.d/* $1/.profile.d
-        fi
+          subdirs+=($subdir)
       fi
 
       if [ -x $dir/bin/release ]; then
@@ -95,6 +86,35 @@ for BUILDPACK in $(cat $1/.buildpacks); do
     fi
   fi
 done
+
+# create a special .profile.d script that sources the
+# .profile.d scripts in sub directories when the app starts
+if [[ -f "$3/SUBDIR_ENABLE_PROFILE_SOURCING" ]]; then
+    mkdir -p $1/.profile.d
+    cat >$1/.profile.d/subdir-buildpack.sh <<EOL
+    #!/usr/bin/env bash
+
+    APP_DIR="\$HOME"
+
+    dirs="${subdirs[@]}"
+    for dir in \$dirs
+    do
+      cd "\$dir"
+      export HOME="\$APP_DIR/\$dir"
+
+      files=\$(find .profile.d -maxdepth 1 -name "*.sh" -type f)
+      for script in \$files
+      do
+        source "\$script"
+      done
+
+      export HOME="\$APP_DIR"
+      cd - > /dev/null
+    done
+EOL
+
+    chmod +x $1/.profile.d/subdir-buildpack.sh
+fi
 
 if [[ -e $1/last_pack_release.out ]]; then
   echo "Using release configuration from last framework ($framework)."

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,19 @@ This would run:
 * The second would `cd` into a `web` directory and use a `node.js` buildpack.
 * The third would be in the root directory and use a `go` buildpack.
 
+## Experimental features
+`.profile.d` scripts are left behind by buildpacks and are invoked by Heroku when the dyno is starting. This allows buildpacks to update the `PATH` environment for example. Since buildpacks can be ran in subdirectories, the `.profile.d` scripts left behind by these buildpacks are not invoked by Heroku.
+
+Support for this recently landed in this buildpack but is still experimental. You can enable it by setting the `SUBDIR_ENABLE_PROFILE_SOURCING` setting on your Heroku app:
+
+    $ heroku config:set SUBDIR_ENABLE_PROFILE_SOURCING=1
+
+You can read more about the role of `.profile.d` scripts in the Heroku documentation:
+
+    https://devcenter.heroku.com/articles/buildpack-api#profile-d-scripts
+
+Note: if you're using the Python or Node.js buildpack, you most likely want to enable this setting.
+
 ## License
 
 MIT

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,8 @@
 # Heroku Buildpack Subdir
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+
 Allows you to compose multiple buildpacks with apps in multiple directories. For information regarding adding multiple buildpacks, check out the official docs [here](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app#adding-a-buildpack).
 
 This buildpack must be at index 1 and all buildpacks following should be at index 2 through N.
@@ -11,15 +14,21 @@ This buildpack must be at index 1 and all buildpacks following should be at inde
 Example `.buildpacks` file:
 
     $ cat .buildpacks
-    api=https://github.com/heroku/heroku-buildpack-ruby.git
-    web=https://github.com/heroku/heroku-buildpack-nodejs.git
+    https://github.com/heroku/heroku-buildpack-nginx
+    api=https://github.com/heroku/heroku-buildpack-ruby
+    web=https://github.com/heroku/heroku-buildpack-nodejs
+    web=https://github.com/heroku/heroku-buildpack-pgbouncer
     https://github.com/heroku/heroku-buildpack-go
 
 This would run:
 
-* The first buildpack would `cd` into an `api` directory and use a `ruby` buildpack.
-* The second would `cd` into a `web` directory and use a `node.js` buildpack.
-* The third would be in the root directory and use a `go` buildpack.
+* The first buildpack would be in the root directory use use the `nginx` buildpack.
+* The second buildpack would `cd` into an `api` directory and use a `ruby` buildpack.
+* The third would `cd` into a `web` directory and use a `nodejs` buildpack.
+* The fourth would `cd` into a `web` directory and use a `pgbouncer` buildpack.
+* The firth would be in the root directory and use a `go` buildpack.
+
+Buildpacks are executed in the order they are declared.
 
 ## Experimental features
 `.profile.d` scripts are left behind by buildpacks and are invoked by Heroku when the dyno is starting. This allows buildpacks to update the `PATH` environment for example. Since buildpacks can be ran in subdirectories, the `.profile.d` scripts left behind by these buildpacks are not invoked by Heroku.
@@ -33,7 +42,3 @@ You can read more about the role of `.profile.d` scripts in the Heroku documenta
     https://devcenter.heroku.com/articles/buildpack-api#profile-d-scripts
 
 Note: if you're using the Python or Node.js buildpack, you most likely want to enable this setting.
-
-## License
-
-MIT


### PR DESCRIPTION
This implements the solution I described in #10 and removes the need for copying specific directories. See the additions I made to the `readme` for more details.

Although sourcing of the `.profile.d` scripts is the desired behavior (see heroku docs), it might cause unintended side effects for those who have been using this buildpack already. That's why I've hidden this new feature behind a flag `SUBDIR_ENABLE_PROFILE_SOURCING`.